### PR TITLE
Python 2 compatibility

### DIFF
--- a/apns2/payload.py
+++ b/apns2/payload.py
@@ -45,7 +45,7 @@ class PayloadAlert(object):
 
 class Payload(object):
     def __init__(self, alert=None, badge=None, sound=None, content_available=None, category=None, custom=None):
-        super().__init__()
+        super(Payload, self).__init__()
         self.alert = alert
         self.badge = badge
         self.sound = sound

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     name='apns2',
     version='0.1.0',
     packages=['apns2'],
-    requires=dependencies,
+    install_requires=dependencies,
     url='https://github.com/Pr0Ger/PyAPNs2',
     license='MIT',
     author='Sergey Petrov',


### PR DESCRIPTION
The only change needed for Python 2 compatibility was changing the call to `super`.
In addition, this fixes a wrong parameter name in `setup.py` which prevented dependencies from being installed.