### PR TITLE
Some changes in client.py for hyper v0.6.0

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -14,12 +14,12 @@ class NotificationPriority(Enum):
 
 
 class APNsClient(object):
-    def __init__(self, cert_file, use_sandbox=False, use_alternative_port=False):
+    def __init__(self, cert_file, use_sandbox=False, use_alternative_port=False, proto=None):
         server = 'api.development.push.apple.com' if use_sandbox else 'api.push.apple.com'
         port = 2197 if use_alternative_port else 443
         ssl_context = init_context()
         ssl_context.load_cert_chain(cert_file)
-        self.__connection = HTTP20Connection(server, port, ssl_context=ssl_context)
+        self.__connection = HTTP20Connection(server, port, ssl_context=ssl_context, force_proto=proto or 'h2')
 
     def send_notification(self, token_hex, notification, priority=NotificationPriority.Immediate, topic=None):
         json_payload = dumps(notification.dict(), ensure_ascii=False, separators=(',', ':')).encode('utf-8')

--- a/apns2/client.py
+++ b/apns2/client.py
@@ -9,8 +9,8 @@ from apns2.errors import exception_class_for_reason
 
 
 class NotificationPriority(Enum):
-    Immediate = 10
-    Delayed = 5
+    Immediate = '10'
+    Delayed = '5'
 
 
 class APNsClient(object):


### PR DESCRIPTION
hyper > common > util > to_bytestring
can not convert INT to byte
and raise ValueError("Non string type.")

------------------

should add force_proto else get proto = None and crash

hyper/http20/connection.py", line 354
assert proto in H2_NPN_PROTOCOLS or proto == H2C_PROTOCOL