### PR TITLE
Fixing bug in automatic casting of PayloadAlert to dict

### DIFF
--- a/apns2/payload.py
+++ b/apns2/payload.py
@@ -56,7 +56,7 @@ class Payload(object):
             'aps': {}
         }
         if self.alert:
-            if self.alert is PayloadAlert:
+            if isinstance(self.alert, PayloadAlert):
                 result['aps']['alert'] = self.alert.dict()
             else:
                 result['aps']['alert'] = self.alert


### PR DESCRIPTION
The `is` comparison doesn’t work, needs to be `isinstance`.