### PR TITLE
Allow using custom JSON conversion class.

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -14,16 +14,16 @@ class NotificationPriority(Enum):
 
 
 class APNsClient(object):
-    def __init__(self, cert_file, use_sandbox=False, use_alternative_port=False, proto=None, json_cls=None):
+    def __init__(self, cert_file, use_sandbox=False, use_alternative_port=False, proto=None, json_encoder=None):
         server = 'api.development.push.apple.com' if use_sandbox else 'api.push.apple.com'
         port = 2197 if use_alternative_port else 443
         ssl_context = init_context()
         ssl_context.load_cert_chain(cert_file)
         self.__connection = HTTP20Connection(server, port, ssl_context=ssl_context, force_proto=proto or 'h2')
-        self.__json_cls=json_cls
+        self.__json_encoder = json_encoder
 
     def send_notification(self, token_hex, notification, priority=NotificationPriority.Immediate, topic=None, expiration=None):
-        json_payload = dumps(notification.dict(), cls=self.__json_cls, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
+        json_payload = dumps(notification.dict(), cls=self.__json_encoder, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
 
         headers = {
             'apns-priority': priority.value

--- a/apns2/client.py
+++ b/apns2/client.py
@@ -14,15 +14,16 @@ class NotificationPriority(Enum):
 
 
 class APNsClient(object):
-    def __init__(self, cert_file, use_sandbox=False, use_alternative_port=False, proto=None):
+    def __init__(self, cert_file, use_sandbox=False, use_alternative_port=False, proto=None, json_cls=None):
         server = 'api.development.push.apple.com' if use_sandbox else 'api.push.apple.com'
         port = 2197 if use_alternative_port else 443
         ssl_context = init_context()
         ssl_context.load_cert_chain(cert_file)
         self.__connection = HTTP20Connection(server, port, ssl_context=ssl_context, force_proto=proto or 'h2')
+        self.__json_cls=json_cls
 
     def send_notification(self, token_hex, notification, priority=NotificationPriority.Immediate, topic=None, expiration=None):
-        json_payload = dumps(notification.dict(), ensure_ascii=False, separators=(',', ':')).encode('utf-8')
+        json_payload = dumps(notification.dict(), cls=self.__json_cls, ensure_ascii=False, separators=(',', ':')).encode('utf-8')
 
         headers = {
             'apns-priority': priority.value


### PR DESCRIPTION
`send_notification` converts the notification to a JSON string, but our content had data types that the JSON converter wouldn't convert. This adds a client setting to set a custom JSON converter.