### PR TITLE
Fix payload behaviour for empty strings / 0 values.

### DIFF
--- a/apns2/payload.py
+++ b/apns2/payload.py
@@ -43,7 +43,7 @@ class PayloadAlert(object):
 
 
 class Payload(object):
-    def __init__(self, alert=None, badge=None, sound=None, content_available=None,
+    def __init__(self, alert=None, badge=None, sound=None, content_available=False,
                  mutable_content=False, category=None, custom=None):
         self.alert = alert
         self.badge = badge
@@ -57,22 +57,22 @@ class Payload(object):
         result = {
             'aps': {}
         }
-        if self.alert:
+        if self.alert is not None:
             if isinstance(self.alert, PayloadAlert):
                 result['aps']['alert'] = self.alert.dict()
             else:
                 result['aps']['alert'] = self.alert
-        if self.badge:
+        if self.badge is not None:
             result['aps']['badge'] = self.badge
-        if self.sound:
+        if self.sound is not None:
             result['aps']['sound'] = self.sound
         if self.content_available:
             result['aps']['content-available'] = 1
         if self.mutable_content:
             result['aps']['mutable-content'] = 1
-        if self.category:
+        if self.category is not None:
             result['aps']['category'] = self.category
-        if self.custom:
+        if self.custom is not None:
             result.update(self.custom)
 
         return result

--- a/apns2/payload.py
+++ b/apns2/payload.py
@@ -43,8 +43,9 @@ class PayloadAlert(object):
 
 
 class Payload(object):
-    def __init__(self, alert=None, badge=None, sound=None, content_available=False,
-                 mutable_content=False, category=None, custom=None):
+    def __init__(self, alert=None, badge=None, sound=None,
+                 content_available=False, mutable_content=False,
+                 category=None, custom=None):
         self.alert = alert
         self.badge = badge
         self.sound = sound


### PR DESCRIPTION
According to the [APNS spec](https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html#//apple_ref/doc/uid/TP40008194-CH107-SW1), the badge value can be `0` or `None`.

The library treats both as the same, though, and will send no badge value in the JSON (and thus a value of `None`) when given an actual value of `0`.

This tries to fix this, using `None` as the default undefined default value where appropriate.