### PR TITLE
Implement thread-id option

### DIFF
--- a/apns2/payload.py
+++ b/apns2/payload.py
@@ -47,7 +47,7 @@ class PayloadAlert(object):
 class Payload(object):
     def __init__(self, alert=None, badge=None, sound=None,
                  content_available=False, mutable_content=False,
-                 category=None, url_args=None, custom=None):
+                 category=None, url_args=None, custom=None, thread_id=None):
         self.alert = alert
         self.badge = badge
         self.sound = sound
@@ -56,6 +56,7 @@ class Payload(object):
         self.url_args = url_args
         self.custom = custom
         self.mutable_content = mutable_content
+        self.thread_id = thread_id
 
     def dict(self):
         result = {
@@ -74,6 +75,8 @@ class Payload(object):
             result['aps']['content-available'] = 1
         if self.mutable_content:
             result['aps']['mutable-content'] = 1
+        if self.thread_id is not None:
+            result['aps']['thread-id'] = self.thread_id
         if self.category is not None:
             result['aps']['category'] = self.category
         if self.url_args is not None:

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -1,0 +1,76 @@
+# pylint: disable=protected-access
+
+from unittest import TestCase
+
+from apns2.payload import Payload, PayloadAlert
+
+
+class PayloadTestCase(TestCase):
+
+    def setUp(self):
+        self.payload_alert = payload_alert = PayloadAlert(
+            title='title', title_localized_key='loc_k', title_localized_args='loc_a',
+            body='body', body_localized_key='body_loc_k', body_localized_args='body_loc_a',
+            action_localized_key='ac_loc_k', action='send',
+            launch_image='img')
+
+    def test_payload(self):
+        payload = Payload(
+            alert='my_alert', badge=2, sound='chime',
+            content_available=1, mutable_content=3,
+            category='my_category', url_args='args', custom={'extra': 'something'}, thread_id=42)
+        self.assertEqual(payload.dict(), {
+            'aps': {
+                'alert': 'my_alert',
+                'badge': 2,
+                'sound': 'chime',
+                'content-available': 1,
+                'mutable-content': 1,
+                'thread-id': 42,
+                'category': 'my_category',
+                'url-args': 'args'
+            },
+            'extra': 'something'
+        })
+
+    def test_payload_with_payload_alert(self):
+        payload = Payload(
+            alert=self.payload_alert, badge=2, sound='chime',
+            content_available=1, mutable_content=1,
+            category='my_category', url_args='args', custom={'extra': 'something'}, thread_id=42)
+        self.assertEqual(payload.dict(), {
+            'aps': {
+                'alert': {
+                    'title': 'title',
+                    'title-loc-key': 'loc_k',
+                    'title-loc-args': 'loc_a',
+                    'body': 'body',
+                    'loc-key': 'body_loc_k',
+                    'loc-args': 'body_loc_a',
+                    'action-loc-key': 'ac_loc_k',
+                    'action': 'send',
+                    'launch-image': 'img'
+                },
+                'badge': 2,
+                'sound': 'chime',
+                'content-available': 1,
+                'mutable-content': 1,
+                'thread-id': 42,
+                'category': 'my_category',
+                'url-args': 'args',
+            },
+            'extra': 'something'
+        })
+
+    def test_payload_alert(self):
+        self.assertEqual(self.payload_alert.dict(), {
+            'title': 'title',
+            'title-loc-key': 'loc_k',
+            'title-loc-args': 'loc_a',
+            'body': 'body',
+            'loc-key': 'body_loc_k',
+            'loc-args': 'body_loc_a',
+            'action-loc-key': 'ac_loc_k',
+            'action': 'send',
+            'launch-image': 'img'
+        })


### PR DESCRIPTION
Implements thread-id payload option, cf. https://developer.apple.com/library/content/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/PayloadKeyReference.html#//apple_ref/doc/uid/TP40008194-CH17-SW1 

Also adds payload tests.