### PR TITLE
Replace use_sandbox/use_alt_port with server/port

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,19 @@ from apns2.payload import Payload
 token_hex = 'b5bb9d8014a0f9b1d61e21e796d78dccdf1352f23cd32812f4850b87'
 payload = Payload(alert="Hello World!", sound="default", badge=1)
 topic = 'com.example.App'
-client = APNsClient('key.pem', use_sandbox=False, use_alternative_port=False)
+client = APNsClient('key.pem')
 client.send_notification(token_hex, payload, topic)
 ```
+
+## Custom hosts
+
+To use APNS sandbox:
+
+client = APNsClient('key.pem', host='api.development.push.apple.com')
+
+To use alternative port:
+
+client = APNsClient('key.pem', port=2197)
 
 ## Further Info
 

--- a/apns2/client.py
+++ b/apns2/client.py
@@ -24,9 +24,7 @@ logger = logging.getLogger(__name__)
 
 
 class APNsClient(object):
-    def __init__(self, cert_file, use_sandbox=False, use_alternative_port=False, proto=None, json_encoder=None):
-        server = 'api.development.push.apple.com' if use_sandbox else 'api.push.apple.com'
-        port = 2197 if use_alternative_port else 443
+    def __init__(self, cert_file, server='api.push.apple.com', port=443, proto=None, json_encoder=None):
         ssl_context = init_context()
         ssl_context.load_cert_chain(cert_file)
         self.__connection = HTTP20Connection(server, port, ssl_context=ssl_context, force_proto=proto or 'h2')


### PR DESCRIPTION
Can be useful to run mock services for custom hosts.

We would need this in our PyAPNS2 implementation in django-push-notifications (see discussion in https://github.com/jleclanche/django-push-notifications/pull/368 for context)