### PR TITLE
Fix _is_expired_token logic error

### DIFF
--- a/apns2/credentials.py
+++ b/apns2/credentials.py
@@ -57,7 +57,7 @@ class TokenCredentials(Credentials):
 
     @staticmethod
     def _is_expired_token(issue_date):
-        return time.time() < issue_date + DEFAULT_TOKEN_LIFETIME
+        return time.time() > issue_date + DEFAULT_TOKEN_LIFETIME
 
     @staticmethod
     def _get_signing_key(key_path):


### PR DESCRIPTION
The expired logic should be: `time.time() > issue_date + DEFAULT_TOKEN_LIFETIME`