### PR TITLE
Always use TLS with HTTP20Connection

### DIFF
--- a/apns2/credentials.py
+++ b/apns2/credentials.py
@@ -17,7 +17,7 @@ class Credentials(object):
     def create_connection(self, server, port, proto, proxy_host=None, proxy_port=None):
         # self.__ssl_context may be none, and that's fine.
         return HTTP20Connection(server, port, ssl_context=self.__ssl_context, force_proto=proto or 'h2',
-                                proxy_host=proxy_host, proxy_port=proxy_port)
+                                secure=True, proxy_host=proxy_host, proxy_port=proxy_port)
 
     def get_authorization_header(self, topic):
         return None


### PR DESCRIPTION
This snippet fixes usage of alternative port (2197) of HTTP/2 APN service.

`hyper` package only uses TLS by default if the port is 443. By adding `secure=True`, we make it use TLS in all circumstances.

http://hyper.readthedocs.io/en/latest/api.html#hyper.HTTP20Connection