### PR TITLE
Add heartbeat option to keep connection alive

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -33,21 +33,21 @@ class APNsClient(object):
     ALTERNATIVE_PORT = 2197
 
     def __init__(self, credentials, use_sandbox=False, use_alternative_port=False, proto=None, json_encoder=None,
-                 password=None, proxy_host=None, proxy_port=None):
+                 password=None, proxy_host=None, proxy_port=None, heartbeat=None):
         if credentials is None or isinstance(credentials, str):
             self.__credentials = CertificateCredentials(credentials, password)
         else:
             self.__credentials = credentials
-        self._init_connection(use_sandbox, use_alternative_port, proto, proxy_host, proxy_port)
+        self._init_connection(use_sandbox, use_alternative_port, proto, proxy_host, proxy_port, heartbeat)
 
         self.__json_encoder = json_encoder
         self.__max_concurrent_streams = None
         self.__previous_server_max_concurrent_streams = None
 
-    def _init_connection(self, use_sandbox, use_alternative_port, proto, proxy_host, proxy_port):
+    def _init_connection(self, use_sandbox, use_alternative_port, proto, proxy_host, proxy_port, heartbeat):
         server = self.SANDBOX_SERVER if use_sandbox else self.LIVE_SERVER
         port = self.ALTERNATIVE_PORT if use_alternative_port else self.DEFAULT_PORT
-        self._connection = self.__credentials.create_connection(server, port, proto, proxy_host, proxy_port)
+        self._connection = self.__credentials.create_connection(server, port, proto, proxy_host, proxy_port, heartbeat)
 
     def send_notification(self, token_hex, notification, topic=None, priority=NotificationPriority.Immediate,
                           expiration=None, collapse_id=None):

--- a/apns2/client.py
+++ b/apns2/client.py
@@ -33,21 +33,21 @@ class APNsClient(object):
     ALTERNATIVE_PORT = 2197
 
     def __init__(self, credentials, use_sandbox=False, use_alternative_port=False, proto=None, json_encoder=None,
-                 password=None, proxy_host=None, proxy_port=None, heartbeat=None):
+                 password=None, proxy_host=None, proxy_port=None, heartbeat_period=None):
         if credentials is None or isinstance(credentials, str):
             self.__credentials = CertificateCredentials(credentials, password)
         else:
             self.__credentials = credentials
-        self._init_connection(use_sandbox, use_alternative_port, proto, proxy_host, proxy_port, heartbeat)
+        self._init_connection(use_sandbox, use_alternative_port, proto, proxy_host, proxy_port, heartbeat_period)
 
         self.__json_encoder = json_encoder
         self.__max_concurrent_streams = None
         self.__previous_server_max_concurrent_streams = None
 
-    def _init_connection(self, use_sandbox, use_alternative_port, proto, proxy_host, proxy_port, heartbeat):
+    def _init_connection(self, use_sandbox, use_alternative_port, proto, proxy_host, proxy_port, heartbeat_period):
         server = self.SANDBOX_SERVER if use_sandbox else self.LIVE_SERVER
         port = self.ALTERNATIVE_PORT if use_alternative_port else self.DEFAULT_PORT
-        self._connection = self.__credentials.create_connection(server, port, proto, proxy_host, proxy_port, heartbeat)
+        self._connection = self.__credentials.create_connection(server, port, proto, proxy_host, proxy_port, heartbeat_period)
 
     def send_notification(self, token_hex, notification, topic=None, priority=NotificationPriority.Immediate,
                           expiration=None, collapse_id=None):

--- a/apns2/credentials.py
+++ b/apns2/credentials.py
@@ -15,31 +15,12 @@ class Credentials(object):
 
     # Creates a connection with the credentials, if available or necessary.
     def create_connection(self, server, port, proto,
-                          proxy_host=None, proxy_port=None, heartbeat_period=None):
+                          proxy_host=None, proxy_port=None):
         # self.__ssl_context may be none, and that's fine.
         connection = HTTP20Connection(server, port, ssl_context=self.__ssl_context,
                                       force_proto=proto or 'h2',
                                       secure=True, proxy_host=proxy_host,
                                       proxy_port=proxy_port)
-
-        if heartbeat_period:
-            import weakref
-            from threading import Thread
-
-            conn_ref = weakref.ref(connection)
-
-            def watchdog():
-                while True:
-                    conn = conn_ref()
-                    if conn is None:
-                        break
-
-                    conn.ping('-' * 8)
-                    time.sleep(heartbeat_period)
-
-            thread = Thread(target=watchdog)
-            thread.setDaemon(True)
-            thread.start()
 
         return connection
 

--- a/apns2/credentials.py
+++ b/apns2/credentials.py
@@ -15,14 +15,14 @@ class Credentials(object):
 
     # Creates a connection with the credentials, if available or necessary.
     def create_connection(self, server, port, proto,
-                          proxy_host=None, proxy_port=None, heartbeat=None):
+                          proxy_host=None, proxy_port=None, heartbeat_period=None):
         # self.__ssl_context may be none, and that's fine.
         connection = HTTP20Connection(server, port, ssl_context=self.__ssl_context,
                                       force_proto=proto or 'h2',
                                       secure=True, proxy_host=proxy_host,
                                       proxy_port=proxy_port)
 
-        if heartbeat:
+        if heartbeat_period:
             import weakref
             from threading import Thread
 
@@ -35,7 +35,7 @@ class Credentials(object):
                         break
 
                     conn.ping('-' * 8)
-                    time.sleep(heartbeat)
+                    time.sleep(heartbeat_period)
 
             thread = Thread(target=watchdog)
             thread.setDaemon(True)

--- a/apns2/credentials.py
+++ b/apns2/credentials.py
@@ -14,15 +14,10 @@ class Credentials(object):
         self.__ssl_context = ssl_context
 
     # Creates a connection with the credentials, if available or necessary.
-    def create_connection(self, server, port, proto,
-                          proxy_host=None, proxy_port=None):
+    def create_connection(self, server, port, proto, proxy_host=None, proxy_port=None):
         # self.__ssl_context may be none, and that's fine.
-        connection = HTTP20Connection(server, port, ssl_context=self.__ssl_context,
-                                      force_proto=proto or 'h2',
-                                      secure=True, proxy_host=proxy_host,
-                                      proxy_port=proxy_port)
-
-        return connection
+        return HTTP20Connection(server, port, ssl_context=self.__ssl_context, force_proto=proto or 'h2',
+                                secure=True, proxy_host=proxy_host, proxy_port=proxy_port)
 
     def get_authorization_header(self, topic):
         return None


### PR DESCRIPTION
This change add the periodic ping.

When connection is not used for several minutes it's may be broken.
To avoid this use hearbeat option to set interval for pinging.
Example: `APNsClient(pem, heartbeat=10)`