### PR TITLE
Adding `apns-push-type` header

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -96,7 +96,10 @@ class APNsClient(object):
         json_str = json.dumps(notification.dict(), cls=self.__json_encoder, ensure_ascii=False, separators=(',', ':'))
         json_payload = json_str.encode('utf-8')
 
-        headers = {}
+        headers = {
+            'apns-push-type': notification.push_type
+        }
+
         if topic is not None:
             headers['apns-topic'] = topic
 

--- a/apns2/payload.py
+++ b/apns2/payload.py
@@ -77,6 +77,10 @@ class Payload(object):
         self.mutable_content = mutable_content
         self.thread_id = thread_id
 
+        self.push_type = 'background'
+        if self.alert or self.badge is not None or self.sound is not None:
+            self.push_type = 'alert'
+
     def dict(self) -> Dict[str, Any]:
         result = {
             'aps': {}

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -50,6 +50,7 @@ def test_payload():
         },
         'extra': 'something'
     }
+    assert payload.push_type == 'alert'
 
 
 def test_payload_with_payload_alert(payload_alert):
@@ -80,3 +81,21 @@ def test_payload_with_payload_alert(payload_alert):
         },
         'extra': 'something'
     }
+    assert payload.push_type == 'alert'
+
+
+def test_payload_with_background_push_type():
+    payload = Payload(
+        content_available=True, mutable_content=True,
+        category='my_category', url_args='args', custom={'extra': 'something'}, thread_id='42')
+    assert payload.dict() == {
+        'aps': {
+            'content-available': 1,
+            'mutable-content': 1,
+            'thread-id': '42',
+            'category': 'my_category',
+            'url-args': 'args',
+        },
+        'extra': 'something'
+    }
+    assert payload.push_type == 'background'


### PR DESCRIPTION
Adding `apns-push-type` header to requests. From apple [documentation](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/sending_notification_requests_to_apns):

> (Required when delivering notifications to devices running iOS 13 and later, or watchOS 6 and later. Ignored on earlier system versions.) The type of the notification. The value of this header is alert or background. Specify alert when the delivery of your notification displays an alert, plays a sound, or badges your app's icon. Specify background for silent notifications that do not interact with the user.
> 
> The value of this header must accurately reflect the contents of your notification's payload. If there is a mismatch, or if the header is missing on required systems, APNs may delay the delivery of the notification or drop it altogether.