### PR TITLE
Fix importing in Python 3.5.2

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -5,9 +5,8 @@ import time
 import typing
 import weakref
 from enum import Enum
-from json import JSONEncoder
 from threading import Thread
-from typing import Dict, Iterable, Optional, Tuple, Type, Union
+from typing import Dict, Iterable, Optional, Tuple, Union
 
 from .credentials import CertificateCredentials, Credentials
 from .errors import ConnectionFailed, exception_class_for_reason
@@ -50,7 +49,7 @@ class APNsClient(object):
     def __init__(self,
                  credentials: Union[Credentials, str],
                  use_sandbox: bool = False, use_alternative_port: bool = False, proto: Optional[str] = None,
-                 json_encoder: Optional[Type[JSONEncoder]] = None, password: Optional[str] = None,
+                 json_encoder: Optional[type] = None, password: Optional[str] = None,
                  proxy_host: Optional[str] = None, proxy_port: Optional[int] = None,
                  heartbeat_period: Optional[float] = None) -> None:
         if isinstance(credentials, str):

--- a/apns2/client.py
+++ b/apns2/client.py
@@ -2,11 +2,12 @@ import collections
 import json
 import logging
 import time
+import typing
 import weakref
 from enum import Enum
 from json import JSONEncoder
 from threading import Thread
-from typing import Deque, Dict, Iterable, Optional, Tuple, Type, Union
+from typing import Dict, Iterable, Optional, Tuple, Type, Union
 
 from .credentials import CertificateCredentials, Credentials
 from .errors import ConnectionFailed, exception_class_for_reason
@@ -185,7 +186,7 @@ class APNsClient(object):
         self.connect()
 
         results = {}
-        open_streams = collections.deque()  # type: Deque[RequestStream]
+        open_streams = collections.deque()  # type: typing.Deque[RequestStream]
         # Loop on the tokens, sending as many requests as possible concurrently to APNs.
         # When reaching the maximum concurrent streams limit, wait for a response before sending
         # another request.


### PR DESCRIPTION
On Ubuntu 16.04, which has Python 3.5.2, `apns2.client` failed to import, because `typing.Deque` was not added until Python 3.5.4, and `Optional[Type[JSONEncoder]]` threw an error until Python 3.5.3 (python/typing#266).

Fixes #88.