### PR TITLE
Do not ignore custom JWT lifetime when using TokenCredentials

### DIFF
--- a/apns2/credentials.py
+++ b/apns2/credentials.py
@@ -60,9 +60,8 @@ class TokenCredentials(Credentials):
         token = self._get_or_create_topic_token()
         return 'bearer %s' % token
 
-    @staticmethod
-    def _is_expired_token(issue_date: float) -> bool:
-        return time.time() > issue_date + DEFAULT_TOKEN_LIFETIME
+    def _is_expired_token(self, issue_date: float) -> bool:
+        return time.time() > issue_date + self.__token_lifetime
 
     @staticmethod
     def _get_signing_key(key_path: str) -> str:


### PR DESCRIPTION
I am not sure that using a fixture in that case is a good idea, because the relevant argument for the test function (the lifetime) is then far from its use. But I did not want to rewrite all the file either.