### PR TITLE
Fix determination of push type for empty notifications with badge 0

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -117,7 +117,11 @@ class APNsClient(object):
                 inferred_push_type = NotificationType.Complication.value
             elif topic.endswith('.pushkit.fileprovider'):
                 inferred_push_type = NotificationType.FileProvider.value
-            elif any([notification.alert, notification.badge, notification.sound]):
+            elif any([
+                notification.alert is not None,
+                notification.badge is not None,
+                notification.sound is not None,
+            ]):
                 inferred_push_type = NotificationType.Alert.value
             else:
                 inferred_push_type = NotificationType.Background.value


### PR DESCRIPTION
Without this change, it is impossible to send an empty notification that just sets the app badge to 0 (removes the badge). If notification.badge is 0, then APNsClient.send_notification_async will calculate the push type as `background`, which will not update the badge number. The solution is to compare `notification.badge` explicitly to `None`.