### PR TITLE
Changing DEFAULT_TOKEN_LIFETIME from 3600 to 2700

### DIFF
--- a/apns2/credentials.py
+++ b/apns2/credentials.py
@@ -9,7 +9,7 @@ from hyper.tls import init_context  # type: ignore
 if TYPE_CHECKING:
     from hyper.ssl_compat import SSLContext  # type: ignore
 
-DEFAULT_TOKEN_LIFETIME = 3600
+DEFAULT_TOKEN_LIFETIME = 2700
 DEFAULT_TOKEN_ENCRYPTION_ALGORITHM = 'ES256'
 
 


### PR DESCRIPTION
I noticed that token-based authentication stops working briefly after about an hour, and found this note on [Establishing a Token-Based Connection to APNs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns):

> Refresh your token no more than once every 20 minutes and no less than once every 60 minutes.

Changing default token lifetime to 45 mins (was 60)