### PR TITLE
Add push_type argument for client.send_notification

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -89,8 +89,9 @@ class APNsClient(object):
 
     def send_notification(self, token_hex: str, notification: Payload, topic: Optional[str] = None,
                           priority: NotificationPriority = NotificationPriority.Immediate,
-                          expiration: Optional[int] = None, collapse_id: Optional[str] = None) -> None:
-        stream_id = self.send_notification_async(token_hex, notification, topic, priority, expiration, collapse_id)
+                          expiration: Optional[int] = None, collapse_id: Optional[str] = None,
+			  push_type: Optional[NotificationType] = None) -> None:
+        stream_id = self.send_notification_async(token_hex, notification, topic, priority, expiration, collapse_id, push_type)
         result = self.get_notification_result(stream_id)
         if result != 'Success':
             if isinstance(result, tuple):


### PR DESCRIPTION
Add a **push_type** argument to client.send_notification. Currently I have to make use of the code to deduce the **push_type** from the **topic**, which is forcing me to create a **topic** when I think it's easier to just pass in the **push_type**

This argument is already present in the method client.send_notification_batch so simply mimicking it.