### PR TITLE
apns2.credentials: since version 2.0.0 pyJWT encode method return str

### DIFF
--- a/.drone.jsonnet
+++ b/.drone.jsonnet
@@ -35,7 +35,6 @@ local Pipeline(py_version) = {
       },
     ],
   },
-  Pipeline("3.5"),
   Pipeline("3.6"),
   Pipeline("3.7"),
   Pipeline("3.8"),
@@ -47,7 +46,6 @@ local Pipeline(py_version) = {
       status: ['success'],
     },
     depends_on: [
-      "tests (Python 3.5)",
       "tests (Python 3.6)",
       "tests (Python 3.7)",
       "tests (Python 3.8)",

--- a/apns2/credentials.py
+++ b/apns2/credentials.py
@@ -87,7 +87,7 @@ class TokenCredentials(Credentials):
             }
             jwt_token = jwt.encode(token_dict, self.__auth_key,
                                    algorithm=self.__encryption_algorithm,
-                                   headers=headers).decode('ascii')
+                                   headers=headers)
 
             # Cache JWT token for later use. One JWT token per connection.
             # https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/establishing_a_token-based_connection_to_apns

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 universal=1
 
 [mypy]
-python_version = 3.5
+python_version = 3.6
 
 # Dynamic typing
 disallow_subclassing_any = True

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ setup(
     packages=['apns2'],
     install_requires=[
         'hyper>=0.7',
-        'PyJWT>=1.4.0,<2.0.0',
+        'PyJWT>=2.0.0',
         'cryptography>=1.7.2',
     ],
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38
+envlist = py36, py37, py38
 
 [testenv]
 commands = pytest {posargs}


### PR DESCRIPTION
PyJWT latest version (2.0.0) introduce the following breaking changes:
- `encode method now return a str instead of bytes`
- `python 3.5 is no longer supported`

see release notes for more informations: https://github.com/jpadilla/pyjwt/releases/tag/2.0.0