### PR TITLE
Set daemon attribute instead of using setDaemon method that was deprecated in Python 3.10

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -84,7 +84,7 @@ class APNsClient(object):
                 time.sleep(heartbeat_period)
 
         thread = Thread(target=watchdog)
-        thread.setDaemon(True)
+        thread.daemon = True
         thread.start()
 
     def send_notification(self, token_hex: str, notification: Payload, topic: Optional[str] = None,


### PR DESCRIPTION
Fixes #130 