### PR TITLE
Add support for NotificationType LiveActivity

### DIFF
--- a/apns2/client.py
+++ b/apns2/client.py
@@ -26,6 +26,7 @@ class NotificationType(Enum):
     VoIP = 'voip'
     Complication = 'complication'
     FileProvider = 'fileprovider'
+    LiveActivity = 'liveactivity'
     MDM = 'mdm'
 
 
@@ -117,6 +118,8 @@ class APNsClient(object):
                 inferred_push_type = NotificationType.Complication.value
             elif topic.endswith('.pushkit.fileprovider'):
                 inferred_push_type = NotificationType.FileProvider.value
+            elif topic.endswith('.push-type.liveactivity'):
+                inferred_push_type = NotificationType.LiveActivity.value
             elif any([
                 notification.alert is not None,
                 notification.badge is not None,


### PR DESCRIPTION
### Description
Apple Introduced Live Activities in iOS 16.1, where updates via remote pushes require usage of a new push type  `liveactivity` 

From the docs: https://developer.apple.com/documentation/activitykit/update-and-end-your-live-activity-with-remote-push-notifications

> 5. Set the value for the apns-push-type header field of the request you sent to APNs to liveactivity.

We can infer it based on the format mentioned in the following statement:

> 6. Set the apns-topic header field of the request you sent to APNs using the following format: <your bundleID>.push-type.liveactivity.

### Test plan

- [x] Successfully update a live activity with topic `com.example.push-type.liveactivity`