### PR TITLE
Feature[alert]: add interruption-level support in the aps payload 

### DIFF
--- a/apns2/payload.py
+++ b/apns2/payload.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List, Optional, Union, Iterable
+from typing import Any, Dict, List, Optional, Union, Iterable, Literal
 
 MAX_PAYLOAD_SIZE = 4096
+
+InterruptionLevelType = Literal['active', 'passive', 'time-sensitive', 'critical']
 
 
 class PayloadAlert(object):
@@ -79,6 +81,7 @@ class Payload(object):
             thread_id: Optional[str] = None,
             content_available: bool = False,
             mutable_content: bool = False,
+            interruption_level: Union[InterruptionLevelType, None] = None,
     ) -> None:
         self.alert = alert
         self.badge = badge
@@ -89,6 +92,18 @@ class Payload(object):
         self.custom = custom
         self.mutable_content = mutable_content
         self.thread_id = thread_id
+        self.interruption_level = interruption_level
+
+    @property
+    def interruption_level(self):
+        return self._interruption_level
+
+    @interruption_level.setter
+    def interruption_level(self, value):
+        if value and value not in InterruptionLevelType.__args__:
+            raise Exception("-interruption_level- it must be at least a value of InterruptionLevelType or None: For further visit https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel. Valid values are: {} ".format(list(InterruptionLevelType.__args__)))
+        self._interruption_level = value
+
 
     def dict(self) -> Dict[str, Any]:
         result = {
@@ -114,6 +129,8 @@ class Payload(object):
             result['aps']['category'] = self.category
         if self.url_args is not None:
             result['aps']['url-args'] = self.url_args
+        if self.interruption_level is not None:
+            result['aps']['interruption-level'] = self.interruption_level
         if self.custom is not None:
             result.update(self.custom)
 

--- a/test/test_payload.py
+++ b/test/test_payload.py
@@ -60,9 +60,17 @@ def test_payload():
 
 def test_payload_with_payload_alert(payload_alert):
     payload = Payload(
-        alert=payload_alert, badge=2, sound='chime',
-        content_available=True, mutable_content=True,
-        category='my_category', url_args='args', custom={'extra': 'something'}, thread_id='42')
+        alert=payload_alert,
+        badge=2,
+        sound="chime",
+        content_available=True,
+        mutable_content=True,
+        category="my_category",
+        url_args="args",
+        custom={"extra": "something"},
+        thread_id="42",
+        interruption_level=None,
+    )
     assert payload.dict() == {
         'aps': {
             'alert': {
@@ -89,3 +97,38 @@ def test_payload_with_payload_alert(payload_alert):
         },
         'extra': 'something'
     }
+
+
+@pytest.mark.parametrize("input_value", ["inactive", "invalid", "default"])
+def test_payload_alert_with_an_unvalid_interruption_level_value(payload_alert, input_value):
+    with pytest.raises(Exception):
+        Payload(
+            alert=payload_alert,
+            badge=2,
+            sound="chime",
+            content_available=True,
+            mutable_content=True,
+            category="my_category",
+            url_args="args",
+            custom={"extra": "something"},
+            thread_id="42",
+            interruption_level=input_value,
+        )
+   
+@pytest.mark.parametrize("input_value", ["active", "passive", "time-sensitive", "critical"])
+def test_payload_alert_with_a_valid_interruption_level_value(payload_alert, input_value):
+    payload = Payload(
+            alert=payload_alert,
+            badge=2,
+            sound="chime",
+            content_available=True,
+            mutable_content=True,
+            category="my_category",
+            url_args="args",
+            custom={"extra": "something"},
+            thread_id="42",
+            interruption_level=input_value,
+        )
+    _payload = payload.dict()
+    assert "interruption-level" in _payload["aps"]
+    assert _payload["aps"]["interruption-level"] == input_value


### PR DESCRIPTION

Based on apple docs 

https://developer.apple.com/documentation/usernotifications/unmutablenotificationcontent/interruptionlevel
<img width="428" alt="image" src="https://github.com/user-attachments/assets/700e8420-977b-49a7-b3bf-e27b345987c4">

GOAL:
Adding _`interruption-level`_ key nested in _`aps`_ 




Proposal Behavior: 
1. Default value for _`interruption_level`_ is _None_ to not impact in current alert behavior.
2. There is a validation in `PayloadAlert` class to restrict _`interruption_level`_  argument only the values defined in Apple docs using by _`typping.Literal`_ and the `setter` decorator for the mentioned argument.

Extra NOTES:

This  effort  is required to support other libraries such as django push notifications issue:->
https://github.com/jazzband/django-push-notifications/issues/708
